### PR TITLE
Install bash in base image as it's required by the start_ckan.sh script

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -60,11 +60,12 @@ WORKDIR ${APP_DIR}
 
 # Install necessary packages to run CKAN
 RUN apk add --no-cache git \
+        bash \
         gettext \
         curl \
         postgresql-client \
         python \
-	libmagic \
+        libmagic \
         apache2-utils && \
     # Create SRC_DIR
     mkdir -p ${SRC_DIR}


### PR DESCRIPTION
Otherwise you get this error when trying to run the image:

    standard_init_linux.go:190: exec user process caused "no such file or directory"