### PR TITLE
Provide a better way to run extra scripts from children images

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -103,6 +103,9 @@ RUN pip install -e /srv/app/src/ckan && \
 # Remove wheels
 RUN rm -rf /srv/app/wheels
 
+# Create entrypoint directory for children image scripts
+ONBUILD RUN mkdir /docker-entrypoint.d
+
 EXPOSE 5000
 
 HEALTHCHECK --interval=10s --timeout=5s --retries=5 CMD curl --fail http://localhost:5000/api/3/action/status_show || exit 1

--- a/rootfs/setup/app/start_ckan.sh
+++ b/rootfs/setup/app/start_ckan.sh
@@ -2,13 +2,25 @@
 # Run the prerun script to init CKAN and create the default admin user
 python prerun.py
 
+# Run any startup scripts provided by images extending this one
+if [[ -d "/docker-entrypoint.d" ]]
+then
+    for f in /docker-entrypoint.d/*; do
+        case "$f" in
+            *.sh)     echo "$0: Running init file $f"; . "$f" ;;
+            *.py)     echo "$0: Running init file $f"; python "$f"; echo ;;
+            *)        echo "$0: Ignoring $f (not an sh or py file)" ;;
+        esac
+        echo
+    done
+fi
+
 # Set the common uwsgi options
 UWSGI_OPTS="--plugins http,python,gevent --socket /tmp/uwsgi.sock --uid 92 --gid 92 --http :5000 --master --enable-threads --paste config:/srv/app/production.ini --lazy-apps --gevent 2000 -p 2 -L"
 
 # Check whether http basic auth password protection is enabled and enable basicauth routing on uwsgi respecfully
 if [ $? -eq 0 ]
 then
-  extra_scripts.sh
   if [ "$PASSWORD_PROTECT" = true ]
   then
     if [ "$HTPASSWD_USER" ] || [ "$HTPASSWD_PASSWORD" ]


### PR DESCRIPTION
The current way requires an `extra_scripts.sh` file to be present on all children images.

With this approach a new folder `/docker-entrypoint.d` is created when an image extends this one. The children image can then copy any shell or python file that they want executed at the start of container in that directory.

For instance consider the following setup:

```
cloud-mysite
├── .env
├── docker-entrypoint.d
│   └── 00_setup_validation.sh
│   └── 01_check_users.py
│   └── this_will_be_ignored.txt
└── Dockerfile
```

The `Dockerfile` will look like:

```
FROM keitaro/ckan:2.8.1

[...]

COPY docker-entrypoint.d/* /docker-entrypoint.d/
```

The files will be executed in alphabetical order.