### PR TITLE
Fix sysadmin creation on 2.8

### DIFF
--- a/rootfs/setup/app/prerun.py
+++ b/rootfs/setup/app/prerun.py
@@ -3,6 +3,7 @@ import sys
 import subprocess
 import psycopg2
 import urllib2
+import re
 
 
 ckan_ini = os.environ.get('CKAN_INI', '/srv/app/production.ini')
@@ -85,7 +86,7 @@ def create_sysadmin():
         command = ['paster', '--plugin=ckan', 'user', name, '-c', ckan_ini]
 
         out = subprocess.check_output(command)
-        if 'User: \nNone\n' not in out:
+        if 'User:None' not in re.sub(r'\s', '', out):
             print '[prerun] Sysadmin user exists, skipping creation'
             return
 


### PR DESCRIPTION
Whitespace changes meant that the check to see if the sysadmin exists no longer worked on CKAN 2.8.