### PR TITLE
Remove uWSGI --plugins option

### DIFF
--- a/rootfs/setup/app/start_ckan.sh
+++ b/rootfs/setup/app/start_ckan.sh
@@ -3,7 +3,7 @@
 python prerun.py
 
 # Set the common uwsgi options
-UWSGI_OPTS="--plugins http,python,gevent --socket /tmp/uwsgi.sock --uid 92 --gid 92 --http :5000 --master --enable-threads --paste config:/srv/app/production.ini --lazy-apps --gevent 2000 -p 2 -L"
+UWSGI_OPTS="--socket /tmp/uwsgi.sock --uid 92 --gid 92 --http :5000 --master --enable-threads --paste config:/srv/app/production.ini --lazy-apps --gevent 2000 -p 2 -L"
 
 # Check whether http basic auth password protection is enabled and enable basicauth routing on uwsgi respecfully
 if [ $? -eq 0 ]


### PR DESCRIPTION
As we are now installing uwsgi via pip these plugins are shipped as part of the code and there's no need to load the plugin, otherwise you get these alarming (but harmless) messages:

```
open("./http_plugin.so"): No such file or directory [core/utils.c line3721]
 !!! UNABLE to load uWSGI plugin: Error loading shared library ./http_plugin.so: No such file or directory !!!

open("./python_plugin.so"): No such file or directory [core/utils.c line 3721]
 !!! UNABLE to load uWSGI plugin: Error loading shared library ./python_plugin.so: No such file or directory !!!

open("./gevent_plugin.so"): No such file or directory [core/utils.c line 3721]
 !!! UNABLE to load uWSGI plugin: Error loading shared library ./gevent_plugin.so: No such file or directory !!!
```