### PR TITLE
Datastore creating at prerun with set permissions

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -107,7 +107,7 @@ RUN pip install -e /srv/app/src/ckan && \
 RUN rm -rf /srv/app/wheels
 
 # Create entrypoint directory for children image scripts
-ONBUILD RUN mkdir /docker-entrypoint.d
+ONBUILD RUN mkdir docker-entrypoint.d
 
 EXPOSE 5000
 

--- a/rootfs/setup/app/start_ckan.sh
+++ b/rootfs/setup/app/start_ckan.sh
@@ -3,7 +3,7 @@
 python prerun.py
 
 # Run any startup scripts provided by images extending this one
-if [[ -d "/docker-entrypoint.d" ]]
+if [[ -d "docker-entrypoint.d" ]]
 then
     for f in /docker-entrypoint.d/*; do
         case "$f" in


### PR DESCRIPTION
We need to set datastore set permissions on database creating. This PR is adding set init datastore method in the prerun.py script