### PR TITLE
Fix check for `docker-entrypoint.d`

### DIFF
--- a/rootfs/setup/app/start_ckan.sh
+++ b/rootfs/setup/app/start_ckan.sh
@@ -3,7 +3,7 @@
 python prerun.py
 
 # Run any startup scripts provided by images extending this one
-if [[ -d "docker-entrypoint.d" ]]
+if [[ -d "/docker-entrypoint.d" ]]
 then
     for f in /docker-entrypoint.d/*; do
         case "$f" in


### PR DESCRIPTION
The entrypoint script checks for the existence of `docker-entrypoint.d` in the CWD, but then run the scripts in `/docker-entrypoint.d`. 

This causes the scripts to either not run at all or fail if an inheriting image changes the `WORKDIR`. 

This fix makes sure the directory is always expected in the filesystem root.