### PR TITLE
Set ckan extensions default level to INFO

### DIFF
--- a/images/ckan/2.7/Dockerfile
+++ b/images/ckan/2.7/Dockerfile
@@ -153,6 +153,8 @@ RUN pip install -e /srv/app/src/ckan && \
     # Generate CKAN config
     paster --plugin=ckan make-config ckan ${APP_DIR}/production.ini && \
     paster --plugin=ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
+    # Set the default level for extensions to INFO
+    paster --plugin=ckan config-tool ${APP_DIR}/production.ini -s logger_ckanext -e level=INFO && \
     # Create the data directory
     mkdir ${DATA_DIR} && \
     # Change ownership to app user

--- a/images/ckan/2.8/Dockerfile
+++ b/images/ckan/2.8/Dockerfile
@@ -147,6 +147,8 @@ RUN pip install -e /srv/app/src/ckan && \
     # Generate CKAN config
     paster --plugin=ckan make-config ckan ${APP_DIR}/production.ini && \
     paster --plugin=ckan config-tool ${APP_DIR}/production.ini "ckan.plugins = ${CKAN__PLUGINS}" && \
+    # Set the default level for extensions to INFO
+    paster --plugin=ckan config-tool ${APP_DIR}/production.ini -s logger_ckanext -e level=INFO && \
     # Create the data directory
     mkdir ${DATA_DIR} && \
     # Change ownership to app user

--- a/images/ckan/2.9/Dockerfile
+++ b/images/ckan/2.9/Dockerfile
@@ -163,6 +163,8 @@ RUN pip install -e /srv/app/src/ckan && \
     mkdir ${DATA_DIR} && \
     # Webassets can't be loaded from env variables at runtime, it needs to be in the config so that it is created
     ckan config-tool ${APP_DIR}/production.ini "ckan.webassets.path = ${DATA_DIR}/webassets" && \
+    # Set the default level for extensions to INFO
+    ckan config-tool ${APP_DIR}/production.ini -s logger_ckanext -e level=INFO && \
     # Change ownership to app user
     chown -R ckan:ckan /srv/app
 


### PR DESCRIPTION
By default `ckan make-config` sets the default log level for CKAN extensions to DEBUG, this change modifies so that the default value is set to INFO.