### PR TITLE
2.9-get-limit-fix

### DIFF
--- a/images/ckan/2.9/patches/00_get_limit_type_check.patch
+++ b/images/ckan/2.9/patches/00_get_limit_type_check.patch
@@ -1,0 +1,13 @@
+--- ckan/ckan/logic/action/get.py	2020-12-09 12:05:49.800909223 +0100
++++ get_limit_type_check.py	2020-12-09 12:11:58.404000000 +0100
+@@ -371,8 +371,8 @@
+             'ckan.group_and_organization_list_all_fields_max', 25)
+     else:
+         max_limit = config.get('ckan.group_and_organization_list_max', 1000)
+-    if limit is None or limit > max_limit:
+-        limit = max_limit
++    if limit is None or int(limit) > max_limit:
++        limit = string(max_limit)
+ 
+     # order_by deprecated in ckan 1.8
+     # if it is supplied and sort isn't use order_by and raise a warning


### PR DESCRIPTION
fixes crash when limit is sent to the get action