### PR TITLE
CKAN alias command for 2.7 and 2.8 so it can be forward-compatible with 2.9

### DIFF
--- a/images/ckan/2.7/Dockerfile
+++ b/images/ckan/2.7/Dockerfile
@@ -166,6 +166,9 @@ RUN rm -rf /srv/app/wheels /srv/app/ext_wheels
 # Copy necessary scripts
 COPY setup/app ${APP_DIR}
 
+# Copy the alias script for paster to be ckan so it's compatible with 2.9
+COPY setup/bin/ckan /usr/bin/ckan
+
 # Create entrypoint directory for children image scripts
 ONBUILD RUN mkdir docker-entrypoint.d
 

--- a/images/ckan/2.7/Dockerfile.focal
+++ b/images/ckan/2.7/Dockerfile.focal
@@ -213,6 +213,9 @@ RUN rm -rf /srv/app/wheels /srv/app/ext_wheels
 # Copy necessary scripts
 COPY setup/app ${APP_DIR}
 
+# Copy the alias script for paster to be ckan so it's compatible with 2.9
+COPY setup/bin/ckan /usr/bin/ckan
+
 # Create entrypoint directory for children image scripts
 ONBUILD RUN mkdir docker-entrypoint.d
 

--- a/images/ckan/2.7/setup/bin/ckan
+++ b/images/ckan/2.7/setup/bin/ckan
@@ -1,0 +1,14 @@
+#!/bin/bash
+# CKAN <2.9 uses paster and the ckan plugin for paster which expects the configuration to be passed
+# to a subcommand, example: paster --plugin=ckan datastore -c /srv/app/production.ini set-permissions
+# CKAN >2.9 ckan CLI command expects the configuration option as the second and third parameter
+# Example: ckan -c /srv/app/production.ini datastore set-permissions
+# 
+# Shift the two arguments so that we can move them to the end of the argument list
+# ckan -c /srv/app/production.ini datastore set-permissions
+# becomes
+# paster --plugin datastore set-permissions -c /srv/app/production.ini
+config_switch=$1
+config_file=$2
+shift 2
+paster --plugin=ckan "$@" "$config_switch" "$config_file"

--- a/images/ckan/2.7/setup/bin/ckan
+++ b/images/ckan/2.7/setup/bin/ckan
@@ -4,11 +4,12 @@
 # CKAN >2.9 ckan CLI command expects the configuration option as the second and third parameter
 # Example: ckan -c /srv/app/production.ini datastore set-permissions
 # 
-# Shift the two arguments so that we can move them to the end of the argument list
+# Shift three arguments so that we can reorder the argument list
 # ckan -c /srv/app/production.ini datastore set-permissions
 # becomes
-# paster --plugin datastore set-permissions -c /srv/app/production.ini
+# paster --plugin datastore -c /srv/app/production.ini set-permissions
 config_switch=$1
 config_file=$2
-shift 2
-paster --plugin=ckan "$@" "$config_switch" "$config_file"
+subcommand=$3
+shift 3
+paster --plugin=ckan "$subcommand" "$config_switch" "$config_file" "$@"

--- a/images/ckan/2.7/setup/bin/ckan
+++ b/images/ckan/2.7/setup/bin/ckan
@@ -7,7 +7,7 @@
 # Shift three arguments so that we can reorder the argument list
 # ckan -c /srv/app/production.ini datastore set-permissions
 # becomes
-# paster --plugin datastore -c /srv/app/production.ini set-permissions
+# paster --plugin=ckan datastore -c /srv/app/production.ini set-permissions
 config_switch=$1
 config_file=$2
 subcommand=$3

--- a/images/ckan/2.8/Dockerfile
+++ b/images/ckan/2.8/Dockerfile
@@ -160,6 +160,9 @@ RUN rm -rf /srv/app/wheels /srv/app/ext_wheels
 # Copy necessary scripts
 COPY setup/app ${APP_DIR}
 
+# Copy the alias script for paster to be ckan so it's compatible with 2.9
+COPY setup/bin/ckan /usr/bin/ckan
+
 # Create entrypoint directory for children image scripts
 ONBUILD RUN mkdir docker-entrypoint.d
 

--- a/images/ckan/2.8/Dockerfile.focal
+++ b/images/ckan/2.8/Dockerfile.focal
@@ -198,6 +198,9 @@ RUN rm -rf /srv/app/wheels /srv/app/ext_wheels
 # Copy necessary scripts
 COPY setup/app ${APP_DIR}
 
+# Copy the alias script for paster to be ckan so it's compatible with 2.9
+COPY setup/bin/ckan /usr/bin/ckan
+
 # Create entrypoint directory for children image scripts
 ONBUILD RUN mkdir docker-entrypoint.d
 

--- a/images/ckan/2.8/setup/bin/ckan
+++ b/images/ckan/2.8/setup/bin/ckan
@@ -1,0 +1,14 @@
+#!/bin/bash
+# CKAN <2.9 uses paster and the ckan plugin for paster which expects the configuration to be passed
+# to a subcommand, example: paster --plugin=ckan datastore -c /srv/app/production.ini set-permissions
+# CKAN >2.9 ckan CLI command expects the configuration option as the second and third parameter
+# Example: ckan -c /srv/app/production.ini datastore set-permissions
+# 
+# Shift the two arguments so that we can move them to the end of the argument list
+# ckan -c /srv/app/production.ini datastore set-permissions
+# becomes
+# paster --plugin datastore set-permissions -c /srv/app/production.ini
+config_switch=$1
+config_file=$2
+shift 2
+paster --plugin=ckan "$@" "$config_switch" "$config_file"

--- a/images/ckan/2.8/setup/bin/ckan
+++ b/images/ckan/2.8/setup/bin/ckan
@@ -4,11 +4,12 @@
 # CKAN >2.9 ckan CLI command expects the configuration option as the second and third parameter
 # Example: ckan -c /srv/app/production.ini datastore set-permissions
 # 
-# Shift the two arguments so that we can move them to the end of the argument list
+# Shift three arguments so that we can reorder the argument list
 # ckan -c /srv/app/production.ini datastore set-permissions
 # becomes
-# paster --plugin datastore set-permissions -c /srv/app/production.ini
+# paster --plugin datastore -c /srv/app/production.ini set-permissions
 config_switch=$1
 config_file=$2
-shift 2
-paster --plugin=ckan "$@" "$config_switch" "$config_file"
+subcommand=$3
+shift 3
+paster --plugin=ckan "$subcommand" "$config_switch" "$config_file" "$@"

--- a/images/ckan/2.8/setup/bin/ckan
+++ b/images/ckan/2.8/setup/bin/ckan
@@ -7,7 +7,7 @@
 # Shift three arguments so that we can reorder the argument list
 # ckan -c /srv/app/production.ini datastore set-permissions
 # becomes
-# paster --plugin datastore -c /srv/app/production.ini set-permissions
+# paster --plugin=ckan datastore -c /srv/app/production.ini set-permissions
 config_switch=$1
 config_file=$2
 subcommand=$3


### PR DESCRIPTION
We need to be able to have forward-compatibility in all our CKAN docker images to 2.9 so that we can develop solutions against 2.9 which will not break 2.8 or 2.7 as long as they are supported. Such solutions like for example https://github.com/keitaroinc/ckan-helm/pull/12.

This adds an alias command `/usr/bin/ckan` to 2.8 and 2.7 which handles the way that 2.9 `ckan` CLI works with `paster` commands in 2.8 and 2.7.