### PR TITLE
Exit CKAN startup if prerun exits

### DIFF
--- a/images/ckan/2.7/setup/app/start_ckan.sh
+++ b/images/ckan/2.7/setup/app/start_ckan.sh
@@ -16,7 +16,7 @@ fi
 UWSGI_OPTS="--socket /tmp/uwsgi.sock --uid 92 --gid 92 --http :5000 --master --enable-threads --paste config:/srv/app/production.ini --paste-logger /srv/app/production.ini --lazy-apps --gevent 2000 -p 2 -L --gevent-early-monkey-patch"
 
 # Run the prerun script to init CKAN and create the default admin user
-python prerun.py
+python prerun.py || { echo '[CKAN prerun] FAILED. Exiting...' ; exit 1; }
 
 # Check if we are in maintenance mode and if yes serve the maintenance pages
 if [ "$MAINTENANCE_MODE" = true ]; then PYTHONUNBUFFERED=1 python maintenance/serve.py; fi

--- a/images/ckan/2.8/setup/app/start_ckan.sh
+++ b/images/ckan/2.8/setup/app/start_ckan.sh
@@ -16,7 +16,7 @@ fi
 UWSGI_OPTS="--socket /tmp/uwsgi.sock --uid 92 --gid 92 --http :5000 --master --enable-threads --paste config:/srv/app/production.ini --paste-logger /srv/app/production.ini --lazy-apps --gevent 2000 -p 2 -L --gevent-early-monkey-patch"
 
 # Run the prerun script to init CKAN and create the default admin user
-python prerun.py
+python prerun.py || { echo '[CKAN prerun] FAILED. Exiting...' ; exit 1; }
 
 # Check if we are in maintenance mode and if yes serve the maintenance pages
 if [ "$MAINTENANCE_MODE" = true ]; then PYTHONUNBUFFERED=1 python maintenance/serve.py; fi

--- a/images/ckan/2.9/setup/app/start_ckan.sh
+++ b/images/ckan/2.9/setup/app/start_ckan.sh
@@ -16,7 +16,7 @@ fi
 UWSGI_OPTS="--socket /tmp/uwsgi.sock --uid ckan --gid ckan --http :5000 --master --enable-threads --wsgi-file /srv/app/wsgi.py --module wsgi:application --lazy-apps --gevent 2000 -p 2 -L --gevent-early-monkey-patch --vacuum --harakiri 50 --callable application"
 
 # Run the prerun script to init CKAN and create the default admin user
-python prerun.py
+python prerun.py || { echo '[CKAN prerun] FAILED. Exiting...' ; exit 1; }
 
 # Check if we are in maintenance mode and if yes serve the maintenance pages
 if [ "$MAINTENANCE_MODE" = true ]; then PYTHONUNBUFFERED=1 python maintenance/serve.py; fi


### PR DESCRIPTION
If prerun.py exits with non-zero exit code then exit the main startup script for CKAN