### PR TITLE
Install rust as cryptography-requirement

### DIFF
--- a/examples/harvest/Dockerfile
+++ b/examples/harvest/Dockerfile
@@ -18,6 +18,11 @@ RUN apk add --no-cache \
         openssl-dev \
         python3-dev 
 
+RUN pip install -U pip
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="/root/.cargo/bin:${PATH}"
+
 # Fetch and build the custom CKAN extensions
 RUN pip wheel --wheel-dir=/wheels git+${HARVEST_GIT_URL}@${HARVEST_GIT_BRANCH}#egg=ckanext-harvest
 RUN pip wheel --wheel-dir=/wheels -r https://raw.githubusercontent.com/ckan/ckanext-harvest/${HARVEST_GIT_BRANCH}/pip-requirements.txt

--- a/examples/harvest/Dockerfile
+++ b/examples/harvest/Dockerfile
@@ -16,12 +16,9 @@ RUN apk add --no-cache \
         g++ \
         libffi-dev \
         openssl-dev \
-        python3-dev 
-
-RUN pip install -U pip
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-
-ENV PATH="/root/.cargo/bin:${PATH}"
+        python3-dev \
+        rust \
+        cargo
 
 # Fetch and build the custom CKAN extensions
 RUN pip wheel --wheel-dir=/wheels git+${HARVEST_GIT_URL}@${HARVEST_GIT_BRANCH}#egg=ckanext-harvest


### PR DESCRIPTION
Setting up the harvest-example did not work for us as installing cryptography-dependency for ckanext-harvest fails with “This package requires Rust >=1.41.0.”.

This added steps updates pip and also installs rust and adds it to the PATH.