### PR TITLE
Revert "check_solr_connection bug fix"

### DIFF
--- a/images/ckan/2.9/setup/app/prerun.py
+++ b/images/ckan/2.9/setup/app/prerun.py
@@ -83,7 +83,6 @@ def check_solr_connection(retry=None):
         conn_info = connection.read()
         # SolrCloud
         conn_info = re.sub(r'"zkConnected":true', '"zkConnected":True', conn_info.decode('utf-8'))
-        conn_info = re.sub(r'"zkConnected":false', '"zkConnected":False', conn_info.decode('utf-8'))
         eval(conn_info)
 
 def init_db():


### PR DESCRIPTION
This fix is causing issues in all docker and kubernetes environments. It's preferred to have CKAN to crash in a docker/kubernetes environment until all of its dependencies are up and running