### PR TITLE
beaker.session.secret fix

### DIFF
--- a/images/ckan/2.7/setup/app/start_ckan.sh
+++ b/images/ckan/2.7/setup/app/start_ckan.sh
@@ -12,10 +12,10 @@ then
     done
 fi
 
-if grep -E "beaker.session.secret ?= ?$" production.ini
+if grep -E "beaker.session.secret ?= ?$" $APP_DIR/production.ini
 then
     echo "Setting beaker.session.secret in ini file"
-    paster --plugin=ckan config-tool $APP_DIR "beaker.session.secret=$(python -c 'import secrets; print(secrets.token_urlsafe())')"
+    paster --plugin=ckan config-tool $APP_DIR/production.ini "beaker.session.secret=$(python -c 'import secrets; print(secrets.token_urlsafe())')"
 fi
 
 # Set the common uwsgi options

--- a/images/ckan/2.8/setup/app/start_ckan.sh
+++ b/images/ckan/2.8/setup/app/start_ckan.sh
@@ -12,10 +12,10 @@ then
     done
 fi
 
-if grep -E "beaker.session.secret ?= ?$" production.ini
+if grep -E "beaker.session.secret ?= ?$" $APP_DIR/production.ini
 then
     echo "Setting beaker.session.secret in ini file"
-    paster --plugin=ckan config-tool $APP_DIR "beaker.session.secret=$(python -c 'import secrets; print(secrets.token_urlsafe())')"
+    paster --plugin=ckan config-tool $APP_DIR/production.ini "beaker.session.secret=$(python -c 'import secrets; print(secrets.token_urlsafe())')"
 fi
 
 # Set the common uwsgi options

--- a/images/ckan/2.9/setup/app/start_ckan.sh
+++ b/images/ckan/2.9/setup/app/start_ckan.sh
@@ -12,12 +12,12 @@ then
     done
 fi
 
-if grep -E "beaker.session.secret ?= ?$" production.ini
+if grep -E "beaker.session.secret ?= ?$" $APP_DIR/production.ini
 then
     echo "Setting secrets in ini file"
-    ckan config-tool $APP_DIR "beaker.session.secret=$(python3 -c 'import secrets; print(secrets.token_urlsafe())')"
-    ckan config-tool $APP_DIR "api_token.jwt.encode.secret=$(python3 -c 'import secrets; print("string:" + secrets.token_urlsafe())')"
-    ckan config-tool $APP_DIR "api_token.jwt.decode.secret=$(python3 -c 'import secrets; print("string:" + secrets.token_urlsafe())')"
+    ckan config-tool $APP_DIR/production.ini "beaker.session.secret=$(python3 -c 'import secrets; print(secrets.token_urlsafe())')"
+    ckan config-tool $APP_DIR/production.ini "api_token.jwt.encode.secret=$(python3 -c 'import secrets; print("string:" + secrets.token_urlsafe())')"
+    ckan config-tool $APP_DIR/production.ini "api_token.jwt.decode.secret=$(python3 -c 'import secrets; print("string:" + secrets.token_urlsafe())')"
 fi
 
 echo "Starting UWSGI with '${UWSGI_PROC_NO:-2}' workers"


### PR DESCRIPTION
The CKAN container does not start with the error:

`Traceback (most recent call last):
  File "/usr/bin/ckan", line 8, in <module>
    sys.exit(ckan())
  File "/usr/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 781, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/usr/lib/python3.8/site-packages/click/core.py", line 700, in make_context
    self.parse_args(ctx, args)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 115, in parse_args
    result = super(ExtendableGroup, self).parse_args(ctx, args)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1212, in parse_args
    rest = Command.parse_args(self, ctx, args)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1048, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1630, in handle_parse_result
    value = invoke_param_callback(self.callback, ctx, self, value)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 123, in invoke_param_callback
    return callback(ctx, param, value)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 125, in _init_ckan_config
    _add_ctx_object(ctx, value)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 134, in _add_ctx_object
    ctx.obj = CtxObject(path)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 56, in __init__
    self.app = make_app(self.config)
  File "/srv/app/src/ckan/ckan/config/middleware/__init__.py", line 58, in make_app
    flask_app = make_flask_stack(conf)
  File "/srv/app/src/ckan/ckan/config/middleware/flask_app.py", line 168, in make_flask_stack
    raise RuntimeError(u'You must provide a value for the secret key'
RuntimeError: You must provide a value for the secret key with the SECRET_KEY config option`

The problem is in the empty beaker.session.secret configuration. This is caused by a wrongly set path in start_ckan.sh