### PR TITLE
Recipent name patch for names containing no utf-8 chars

### DIFF
--- a/images/ckan/2.9/patches/04_patch_smtp_aws_recipient_name.patch
+++ b/images/ckan/2.9/patches/04_patch_smtp_aws_recipient_name.patch
@@ -1,0 +1,11 @@
+--- a/ckan/lib/mailer.py
++++ b/ckan/lib/mailer.py
+@@ -121,7 +121,7 @@ def mail_recipient(recipient_name, recipient_email, subject,
+     '''Sends an email'''
+     site_title = config.get('ckan.site_title')
+     site_url = config.get('ckan.site_url')
+-    return _mail_recipient(recipient_name, recipient_email,
++    return _mail_recipient("", recipient_email,
+                            site_title, site_url, subject, body,
+                            body_html=body_html, headers=headers)
+ 


### PR DESCRIPTION
Adds patch so when user that contains non utf-8 characters in his name or surname recives the mail. 