### PR TITLE
Restore PyYAML 5.4.1 to avoid TypeError in webassets 0.12.1

### DIFF
--- a/images/ckan/2.9/Dockerfile
+++ b/images/ckan/2.9/Dockerfile
@@ -60,10 +60,11 @@ COPY ./scripts/apply_ckan_patches.sh ${SRC_DIR}/apply_ckan_patches.sh
 RUN cd ${SRC_DIR} && ls -lah ${SRC_DIR} && ash ${SRC_DIR}/apply_ckan_patches.sh
 RUN rm -rf /srv/app/src/ckan/.git
 
-#### PATCH SINCE CYTON UPDATED TO 3.0.0 ###
-RUN sed -i 's/pyyaml==5.4.1/pyyaml>=6.0.1/g' ckan/requirements.txt
+# Create a constraint file that limits the Cython version to a compatible one, see https://github.com/yaml/pyyaml/issues/736
+RUN echo 'Cython < 3.0' > /tmp/constraint.txt
+RUN PIP_CONSTRAINT=/tmp/constraint.txt pip wheel --wheel-dir=/wheels PyYAML==5.4.1
 
-# RUN pip-compile ckan/requirements.in 
+# RUN pip-compile ckan/requirements.in
 RUN pip wheel --wheel-dir=/wheels -r ckan/requirements.txt
 RUN pip wheel --wheel-dir=/wheels uWSGI==2.0.20 gevent==21.12.0 greenlet==1.1.3
 


### PR DESCRIPTION
The patch to bump pyyaml to 6.0.1 introduced in https://github.com/keitaroinc/docker-ckan/pull/108/files#diff-132f494f7fa90591cc8efc8b166716154979ee515aa16ab9fd614f82b92a9f07R64 is raising an error when running the CKAN 2.9 image. [CKAN 2.9.9 requires webassets 0.12.1](https://github.com/ckan/ckan/blob/ckan-2.9.9/requirements.in#L36), which [calls yaml.load() without a Loader](https://github.com/miracle2k/webassets/blob/0.12.1/src/webassets/loaders.py#L201). This generated a warning in pyyaml 5.4.1, but [raises a TypeError in 6.x](https://github.com/yaml/pyyaml/blob/155ec463f6a854ac14ccd5e2dda8017ce42a508a/CHANGES#L21). Unfortunately, there's an issue building PyYAML < 6.0.1 from source because it's not compatible with Cython 3, so this PR follows the workaround suggested in https://github.com/yaml/pyyaml/issues/736 to create a constraint file that limits the Cython version to one that should work and restores pyyaml to 5.4.1.

```
Traceback (most recent call last):
  File "/usr/bin/ckan", line 8, in <module>
    sys.exit(ckan())
  File "/usr/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 781, in main
    with self.make_context(prog_name, args, **extra) as ctx:
  File "/usr/lib/python3.8/site-packages/click/core.py", line 700, in make_context
    self.parse_args(ctx, args)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 116, in parse_args
    result = super(ExtendableGroup, self).parse_args(ctx, args)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1212, in parse_args
    rest = Command.parse_args(self, ctx, args)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1048, in parse_args
    value, args = param.handle_parse_result(ctx, opts, args)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 1630, in handle_parse_result
    value = invoke_param_callback(self.callback, ctx, self, value)
  File "/usr/lib/python3.8/site-packages/click/core.py", line 123, in invoke_param_callback
    return callback(ctx, param, value)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 126, in _init_ckan_config
    _add_ctx_object(ctx, value)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 135, in _add_ctx_object
    ctx.obj = CtxObject(path)
  File "/srv/app/src/ckan/ckan/cli/cli.py", line 57, in __init__
    self.app = make_app(self.config)
  File "/srv/app/src/ckan/ckan/config/middleware/__init__.py", line 56, in make_app
    load_environment(conf)
  File "/srv/app/src/ckan/ckan/config/environment.py", line 123, in load_environment
    p.load_all()
  File "/srv/app/src/ckan/ckan/plugins/core.py", line 161, in load_all
    unload_all()
  File "/srv/app/src/ckan/ckan/plugins/core.py", line 208, in unload_all
    unload(*reversed(_PLUGINS))
  File "/srv/app/src/ckan/ckan/plugins/core.py", line 236, in unload
    plugins_update()
  File "/srv/app/src/ckan/ckan/plugins/core.py", line 153, in plugins_update
    environment.update_config()
  File "/srv/app/src/ckan/ckan/config/environment.py", line 172, in update_config
    webassets_init()
  File "/srv/app/src/ckan/ckan/lib/webassets_tools.py", line 67, in webassets_init
    create_library(u'vendor', os.path.join(
  File "/srv/app/src/ckan/ckan/lib/webassets_tools.py", line 28, in create_library
    library = YAMLLoader(config_path).load_bundles()
  File "/usr/lib/python3.8/site-packages/webassets/loaders.py", line 162, in load_bundles
    obj = self.yaml.load(f) or {}
TypeError: load() missing 1 required positional argument: 'Loader'
```

cc @Filip3mac 