### PR TITLE
Bump trivy-action from 0.24.0 to v0.36.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         run: docker build -t internal/ckan/${{ matrix.version }}:${{ github.sha }} ./images/ckan/${{ matrix.version }}/
 
       - name: Run Trivy on image ${{ matrix.version }}
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'internal/ckan/${{ matrix.version }}:${{ github.sha }}'
           format: 'sarif'


### PR DESCRIPTION
## Summary

Bump `aquasecurity/trivy-action` from `0.24.0` to `v0.36.0` in `.github/workflows/ci.yml`.

## Root Cause

`trivy-action@0.24.0` was removed from the GitHub Actions marketplace, causing the Security Scan CI job to fail with:
```
Unable to resolve action `aquasecurity/trivy-action@0.24.0`, unable to find version `0.24.0`
```

## Test Plan
- [x] CI Security Scan job should pass with the updated action version